### PR TITLE
[Fix] 멤버십 사용 내역 화면 디자인 수정

### DIFF
--- a/app/src/main/java/com/project/drinkly/ui/subscribe/OrderHistoryFragment.kt
+++ b/app/src/main/java/com/project/drinkly/ui/subscribe/OrderHistoryFragment.kt
@@ -43,13 +43,6 @@ class OrderHistoryFragment : Fragment() {
 
         initAdapter()
 
-        binding.run {
-            recyclerViewOrderHistory.apply {
-                adapter = orderHistoryAdapter
-                layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
-            }
-        }
-
         return binding.root
     }
 
@@ -59,46 +52,48 @@ class OrderHistoryFragment : Fragment() {
     }
 
     fun initAdapter() {
-        getOrderHistory = (viewModel.orderHistory.value?.drinksHistory ?: emptyList<OrderHistory>()).toMutableList()
+        getOrderHistory = (viewModel.orderHistory.value?.drinksHistory ?: emptyList()).toMutableList()
 
         binding.run {
-            if(getOrderHistory.size == 0) {
+            if(getOrderHistory.isEmpty()) {
                 layoutEmpty.visibility = View.VISIBLE
                 recyclerViewOrderHistory.visibility = View.GONE
             } else {
                 layoutEmpty.visibility = View.GONE
                 recyclerViewOrderHistory.visibility = View.VISIBLE
             }
-        }
 
-        orderHistoryAdapter = OrderHistoryAdapter(
-            mainActivity,
-            getOrderHistory
-        ).apply {
-            itemClickListener = object : OrderHistoryAdapter.OnItemClickListener {
-                override fun onItemClick(position: Int) {
-                    mixpanel.track("click_subscribe_history_detail", null)
+            orderHistoryAdapter = OrderHistoryAdapter(mainActivity, getOrderHistory).apply {
+                itemClickListener = object : OrderHistoryAdapter.OnItemClickListener {
+                    override fun onItemClick(position: Int) {
+                        mixpanel.track("click_subscribe_history_detail", null)
 
-                    val bundle = Bundle().apply {
-                        putString("storeName", getOrderHistory[position].storeName.toString())
-                        putString("drinkName", getOrderHistory[position].providedDrink.toString())
-                        putString("usedDate", getOrderHistory[position].usageDate)
-                        putBoolean("isUsed", true)
+                        val bundle = Bundle().apply {
+                            putString("storeName", getOrderHistory[position].storeName.toString())
+                            putString("drinkName", getOrderHistory[position].providedDrink.toString())
+                            putString("usedDate", getOrderHistory[position].usageDate)
+                            putBoolean("isUsed", true)
+                        }
+
+                        val nextFragment = StoreMembershipFragment().apply {
+                            arguments = bundle
+                        }
+
+                        mainActivity.supportFragmentManager.beginTransaction()
+                            .replace(R.id.fragmentContainerView_main, nextFragment)
+                            .addToBackStack("membership")
+                            .commit()
                     }
-
-                    // 전달할 Fragment 생성
-                    var nextFragment = StoreMembershipFragment().apply {
-                        arguments = bundle // 생성한 Bundle을 Fragment의 arguments에 설정
-                    }
-
-                    mainActivity.supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragmentContainerView_main, nextFragment)
-                        .addToBackStack("membership")
-                        .commit()
                 }
+            }
+
+            recyclerViewOrderHistory.apply {
+                layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+                adapter = orderHistoryAdapter
             }
         }
     }
+
 
     fun initView() {
         mainActivity.run {

--- a/app/src/main/res/layout/fragment_order_history.xml
+++ b/app/src/main/res/layout/fragment_order_history.xml
@@ -43,13 +43,14 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView_order_history"
                 android:layout_width="0dp"
-                android:layout_height="0dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:layout_marginBottom="10dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView_title" />
+                app:layout_constraintTop_toBottomOf="@+id/textView_title"
+                app:layout_constraintVertical_bias="0.0" />
 
             <LinearLayout
                 android:id="@+id/layout_empty"

--- a/app/src/main/res/layout/fragment_store_membership.xml
+++ b/app/src/main/res/layout/fragment_store_membership.xml
@@ -16,6 +16,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -144,6 +145,18 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView_membership_guide_title" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <View
+                android:id="@+id/divider"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:layout_marginHorizontal="10dp"
+                android:background="@color/gray8"
+                app:layout_constraintStart_toStartOf="@+id/layout_membership_guide"
+                app:layout_constraintEnd_toEndOf="@+id/layout_membership_guide"
+                app:layout_constraintTop_toBottomOf="@+id/layout_membership_guide"
+                app:layout_constraintBottom_toTopOf="@+id/layout_caution"/>
+
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_caution"


### PR DESCRIPTION
## 🔎 What type of PR is this? (check all applicable)

- [ ] Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update
- [ ] Others: ...

## 📝 Changes 
<!-- 작업한 내용을 작성해주세요-->
멤버십 사용 내역 화면 디자인 수정

## 🐥 What need this change? 
- Related Issues : #50 
- Closes : #50 


## 📷 Screenshots, Recordings (optional)

## 👫 To Reviewers (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 주문 내역 화면에서 RecyclerView의 높이와 배치가 개선되어 더 자연스러운 화면 구성이 제공됩니다.
  * 멤버십 안내와 주의사항 섹션 사이에 구분선이 추가되어 시각적으로 구역이 명확하게 구분됩니다.

* **리팩터링**
  * 주문 내역 화면의 내부 코드가 더 간결하고 일관성 있게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->