### PR TITLE
[Feat] 쿠폰 화면 쿠폰 모두보기 기능 구현

### DIFF
--- a/app/src/main/java/com/project/drinkly/api/ApiService.kt
+++ b/app/src/main/java/com/project/drinkly/api/ApiService.kt
@@ -207,6 +207,13 @@ interface ApiService {
         @Path("couponId") couponId: Long
     ): Call<BaseResponse<String?>>
 
+    // 쿠폰 전체 다운로드
+    @POST("/api/v1/coupon/m/issue/store/{storeId}")
+    fun downloadAllCoupon(
+        @Header("Authorization") token: String,
+        @Path("storeId") couponId: Long
+    ): Call<BaseResponse<String?>>
+
     // 멤버십 쿠폰 사용
     @POST("/api/v1/payment/m/coupon-use")
     fun useMembershipCoupon(

--- a/app/src/main/java/com/project/drinkly/api/ApiService.kt
+++ b/app/src/main/java/com/project/drinkly/api/ApiService.kt
@@ -211,7 +211,7 @@ interface ApiService {
     @POST("/api/v1/coupon/m/issue/store/{storeId}")
     fun downloadAllCoupon(
         @Header("Authorization") token: String,
-        @Path("storeId") couponId: Long
+        @Path("storeId") storeId: Long
     ): Call<BaseResponse<String?>>
 
     // 멤버십 쿠폰 사용

--- a/app/src/main/java/com/project/drinkly/ui/MainActivity.kt
+++ b/app/src/main/java/com/project/drinkly/ui/MainActivity.kt
@@ -9,6 +9,7 @@ import android.util.Base64
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
@@ -43,6 +44,9 @@ class MainActivity : AppCompatActivity() {
     lateinit var sharedPreferenceManager: PreferenceUtil
 
     private var pendingPushStoreId: Long? = null
+
+    private var backPressedTime: Long = 0
+    private val FINISH_INTERVAL_TIME: Long = 2000 // 2초
 
     @RequiresApi(Build.VERSION_CODES.P)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -273,6 +277,26 @@ class MainActivity : AppCompatActivity() {
             if (this::sharedPreferenceManager.isInitialized) {
                 sharedPreferenceManager.setFCMToken(token)
             }
+        }
+    }
+
+    override fun onBackPressed() {
+        val currentFragment = supportFragmentManager.findFragmentById(R.id.fragmentContainerView_main)
+
+        // 백스택이 비어있고, 현재 화면이 첫 화면일 경우 → 두 번 눌러 종료 로직
+        if (supportFragmentManager.backStackEntryCount == 0 && (currentFragment is LoginFragment || currentFragment is StoreMapFragment || currentFragment is SubscribeFragment || currentFragment is MypageFragment)) {
+            val tempTime = System.currentTimeMillis()
+            val intervalTime = tempTime - backPressedTime
+
+            if (intervalTime in 0..FINISH_INTERVAL_TIME) {
+                super.onBackPressed() // 앱 종료
+            } else {
+                backPressedTime = tempTime
+                Toast.makeText(this, "한 번 더 누르면 앱이 종료됩니다", Toast.LENGTH_SHORT).show()
+            }
+        } else {
+            // 기본 뒤로가기 동작
+            super.onBackPressed()
         }
     }
 }

--- a/app/src/main/java/com/project/drinkly/ui/MainActivity.kt
+++ b/app/src/main/java/com/project/drinkly/ui/MainActivity.kt
@@ -97,7 +97,6 @@ class MainActivity : AppCompatActivity() {
 
                     supportFragmentManager.beginTransaction()
                         .replace(R.id.fragmentContainerView_main, StoreMapFragment())
-                        .addToBackStack(null)
                         .commit()
                     true
                 }
@@ -113,7 +112,6 @@ class MainActivity : AppCompatActivity() {
 
                                 supportFragmentManager.beginTransaction()
                                     .replace(R.id.fragmentContainerView_main, SubscribeFragment())
-                                    .addToBackStack(null)
                                     .commit()
                             } else {
                                 Log.e("SubscriptionCheck", "❌ 상태 체크 실패")
@@ -131,7 +129,6 @@ class MainActivity : AppCompatActivity() {
 
                         supportFragmentManager.beginTransaction()
                             .replace(R.id.fragmentContainerView_main, nextFragment)
-                            .addToBackStack(null)
                             .commit()
                     }
                     true
@@ -148,7 +145,6 @@ class MainActivity : AppCompatActivity() {
 
                                 supportFragmentManager.beginTransaction()
                                     .replace(R.id.fragmentContainerView_main, MypageFragment())
-                                    .addToBackStack(null)
                                     .commit()
                             } else {
                                 Log.e("SubscriptionCheck", "❌ 상태 체크 실패")
@@ -166,7 +162,6 @@ class MainActivity : AppCompatActivity() {
 
                         supportFragmentManager.beginTransaction()
                             .replace(R.id.fragmentContainerView_main, nextFragment)
-                            .addToBackStack(null)
                             .commit()
                     }
                     true

--- a/app/src/main/java/com/project/drinkly/ui/store/CouponListBottomSheetFragment.kt
+++ b/app/src/main/java/com/project/drinkly/ui/store/CouponListBottomSheetFragment.kt
@@ -1,24 +1,38 @@
 package com.project.drinkly.ui.store
 
 import android.app.Activity
+import android.app.Dialog
+import android.content.res.Resources
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.project.drinkly.R
 import com.project.drinkly.api.response.coupon.StoreCouponResponse
 import com.project.drinkly.databinding.FragmentCouponListBottomSheetBinding
+import com.project.drinkly.ui.BasicToast
 import com.project.drinkly.ui.MainActivity
 import com.project.drinkly.ui.store.adapter.StoreDetailCouponAdapter
+import com.project.drinkly.ui.store.viewModel.StoreViewModel
+import com.project.drinkly.util.GlobalApplication.Companion.mixpanel
 
-class CouponListBottomSheetFragment(var activity: Activity, var coupons: MutableList<StoreCouponResponse>?) : BottomSheetDialogFragment() {
+class CouponListBottomSheetFragment(var activity: MainActivity, var coupons: MutableList<StoreCouponResponse>?, var storeId: Long, var storeName: String) : BottomSheetDialogFragment() {
 
     lateinit var binding: FragmentCouponListBottomSheetBinding
     lateinit var mainActivity: MainActivity
+    private val viewModel: StoreViewModel by lazy {
+        ViewModelProvider(requireActivity())[StoreViewModel::class.java]
+    }
 
     lateinit var storeCouponAdapter: StoreDetailCouponAdapter
+
+    private var couponInfo: MutableList<StoreCouponResponse>? = null
 
     interface OnCouponClickListener {
         fun onBottomSheetClicked(position: Int, type: String)
@@ -35,11 +49,20 @@ class CouponListBottomSheetFragment(var activity: Activity, var coupons: Mutable
         mainActivity = activity as MainActivity
 
         initAdapter()
+        observeViewModel()
 
         binding.run {
             recyclerViewCoupon.apply {
                 adapter = storeCouponAdapter
                 layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+            }
+
+            buttonDownloadAll.setOnClickListener {
+                // 쿠폰 전체 다운로드
+                viewModel.downloadAllCoupon(activity, storeId) {
+                    viewModel.getStoreCoupon(activity, storeId)
+                    BasicToast.showBasicToast(requireContext(), "쿠폰 다운로드가 완료되었어요", R.drawable.ic_check, binding.buttonDownloadAll)
+                }
             }
 
             buttonClose.setOnClickListener {
@@ -50,6 +73,27 @@ class CouponListBottomSheetFragment(var activity: Activity, var coupons: Mutable
         return binding.root
     }
 
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+
+        dialog.setOnShowListener { dialogInterface ->
+            val bottomSheet = (dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)) as View
+            val behavior = BottomSheetBehavior.from(bottomSheet)
+
+            bottomSheet.layoutParams.height = getHalfScreenHeight()
+            behavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            behavior.peekHeight = getHalfScreenHeight()
+        }
+
+        return dialog
+    }
+
+    private fun getHalfScreenHeight(): Int {
+        val displayMetrics = Resources.getSystem().displayMetrics
+        return (displayMetrics.heightPixels * 0.7).toInt()
+    }
+
+
     fun initAdapter() {
         storeCouponAdapter = StoreDetailCouponAdapter(
             mainActivity,
@@ -57,16 +101,65 @@ class CouponListBottomSheetFragment(var activity: Activity, var coupons: Mutable
         ).apply {
             itemClickListener = object : StoreDetailCouponAdapter.OnItemClickListener {
                 override fun onItemClick(position: Int, type: String) {
-                    clickListener?.onBottomSheetClicked(position, type)
+                    useCoupon(position, type)
                 }
             }
         }
     }
 
-    fun updateCouponList(updatedList: List<StoreCouponResponse>?) {
-        coupons?.clear()
-        coupons?.addAll(updatedList ?: emptyList())
-        storeCouponAdapter.updateList(coupons)
-        storeCouponAdapter.notifyDataSetChanged()
+    fun observeViewModel() {
+        viewModel.run {
+            // 쿠폰 데이터
+            storeCouponInfo.observe(viewLifecycleOwner) {
+                couponInfo = it
+
+                println("쿠폰 데이터 업데이트 ${couponInfo}")
+                storeCouponAdapter.updateList(couponInfo)
+            }
+        }
+    }
+
+    fun useCoupon(position: Int, status: String) {
+        when (status) {
+            "NONE" -> {
+                mixpanel.track("click_detail_coupon_download", null)
+
+                // (쿠폰 다운로드 전) 쿠폰 다운로드
+                viewModel.downloadCoupon(
+                    mainActivity,
+                    couponInfo?.get(position)?.id ?: 0L,
+                    storeId
+                ) {
+                    BasicToast.showBasicToast(requireContext(), "쿠폰 다운로드가 완료되었어요", R.drawable.ic_check, binding.buttonDownloadAll)
+                }
+            }
+
+            "AVAILABLE" -> {
+                mixpanel.track("move_detail_to_coupon_use", null)
+
+                // (쿠폰 다운로드 후 사용 X) 쿠폰 사용 화면으로 이동
+                val bundle = Bundle().apply {
+                    putString("storeName", storeName.toString())
+                    putLong("couponId", couponInfo?.get(position)?.id ?: 0)
+                    putString("couponTitle", couponInfo?.get(position)?.title)
+                    putString("couponDescription", couponInfo?.get(position)?.description)
+                    putString("couponDate", couponInfo?.get(position)?.expirationDate)
+                }
+
+                // 전달할 Fragment 생성
+                var nextFragment = StoreCouponFragment().apply {
+                    arguments = bundle // 생성한 Bundle을 Fragment의 arguments에 설정
+                }
+
+                mainActivity.supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragmentContainerView_main, nextFragment)
+                    .addToBackStack(null)
+                    .commit()
+            }
+
+            "USED" -> {
+                // (쿠폰 사용 완료)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/project/drinkly/ui/store/CouponListBottomSheetFragment.kt
+++ b/app/src/main/java/com/project/drinkly/ui/store/CouponListBottomSheetFragment.kt
@@ -120,6 +120,8 @@ class CouponListBottomSheetFragment(var activity: MainActivity, var coupons: Mut
     }
 
     fun useCoupon(position: Int, status: String) {
+        val coupon = couponInfo?.getOrNull(position) ?: return
+
         when (status) {
             "NONE" -> {
                 mixpanel.track("click_detail_coupon_download", null)
@@ -127,7 +129,7 @@ class CouponListBottomSheetFragment(var activity: MainActivity, var coupons: Mut
                 // (쿠폰 다운로드 전) 쿠폰 다운로드
                 viewModel.downloadCoupon(
                     mainActivity,
-                    couponInfo?.get(position)?.id ?: 0L,
+                    coupon.id,
                     storeId
                 ) {
                     BasicToast.showBasicToast(requireContext(), "쿠폰 다운로드가 완료되었어요", R.drawable.ic_check, binding.buttonDownloadAll)
@@ -140,10 +142,10 @@ class CouponListBottomSheetFragment(var activity: MainActivity, var coupons: Mut
                 // (쿠폰 다운로드 후 사용 X) 쿠폰 사용 화면으로 이동
                 val bundle = Bundle().apply {
                     putString("storeName", storeName.toString())
-                    putLong("couponId", couponInfo?.get(position)?.id ?: 0)
-                    putString("couponTitle", couponInfo?.get(position)?.title)
-                    putString("couponDescription", couponInfo?.get(position)?.description)
-                    putString("couponDate", couponInfo?.get(position)?.expirationDate)
+                    putLong("couponId",  coupon.id)
+                    putString("couponTitle",  coupon.title)
+                    putString("couponDescription", coupon.description)
+                    putString("couponDate", coupon.expirationDate)
                 }
 
                 // 전달할 Fragment 생성

--- a/app/src/main/java/com/project/drinkly/ui/store/StoreDetailFragment.kt
+++ b/app/src/main/java/com/project/drinkly/ui/store/StoreDetailFragment.kt
@@ -269,15 +269,7 @@ class StoreDetailFragment : Fragment() {
     fun clickCoupon(position: Int, status: String) {
         if((couponInfo?.size ?: 0) > 1) {
             // 쿠폰 모두보기 bottom sheet
-            val couponBottomSheet = CouponListBottomSheetFragment(mainActivity, couponInfo)
-
-            couponBottomSheet.apply {
-                clickListener = object : CouponListBottomSheetFragment.OnCouponClickListener {
-                    override fun onBottomSheetClicked(position: Int, type: String) {
-                        useCoupon(position, type)
-                    }
-                }
-            }
+            val couponBottomSheet = CouponListBottomSheetFragment(mainActivity, couponInfo, getStoreDetailInfo?.storeId ?: 0, getStoreDetailInfo?.storeName.toString())
 
             couponBottomSheet.show(childFragmentManager, couponBottomSheet.tag)
         } else {

--- a/app/src/main/res/drawable/background_button_transparent.xml
+++ b/app/src/main/res/drawable/background_button_transparent.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid android:color="#232846"/>
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/primary_50" />
+
+    <corners android:radius="50dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_coupon_list_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_coupon_list_bottom_sheet.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/background"
-    android:paddingHorizontal="20dp"
     tools:context=".ui.store.CouponListBottomSheetFragment" >
 
     <ImageView
@@ -23,7 +22,8 @@
         style="@style/HeadLine4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="19dp"
+        android:layout_marginStart="20dp"
         android:text="쿠폰 전체보기"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/imageView_handle" />
@@ -32,24 +32,65 @@
         android:id="@+id/button_close"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="20dp"
         android:src="@drawable/ic_close_gray6"
         app:layout_constraintBottom_toBottomOf="@+id/textView_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/textView_title" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView_coupon"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:maxHeight="500dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginBottom="43dp"
-        app:layout_constraintBottom_toTopOf="@+id/button_download_all"
-        app:layout_constraintStart_toStartOf="parent"
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:background="@color/gray9"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView_title" >
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView_title" />
 
-    </androidx.recyclerview.widget.RecyclerView>
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
+        app:layout_constraintVertical_bias="0.0">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp">
+
+            <Space
+                android:id="@+id/space"
+                android:layout_width="match_parent"
+                android:layout_height="12dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView_coupon"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="180dp"
+                app:layout_constraintTop_toBottomOf="@id/space"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:layout_height="250dp"
+        android:background="@drawable/background_gradient_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
         android:id="@+id/button_download_all"
@@ -58,7 +99,8 @@
         android:layout_height="wrap_content"
         android:paddingVertical="12dp"
         android:layout_marginBottom="30dp"
-        android:background="@drawable/background_edittext_success"
+        android:layout_marginHorizontal="20dp"
+        android:background="@drawable/background_button_transparent"
         android:text="모두 다운받기"
         android:textAlignment="center"
         android:textColor="@color/primary_40"

--- a/app/src/main/res/layout/layout_membership_coupon.xml
+++ b/app/src/main/res/layout/layout_membership_coupon.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="15dp">
+    android:layout_marginBottom="20dp">
 
 
     <LinearLayout

--- a/app/src/main/res/layout/layout_store_coupon.xml
+++ b/app/src/main/res/layout/layout_store_coupon.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="15dp">
+    android:layout_marginBottom="20dp">
 
     <LinearLayout
         android:id="@+id/layout_coupon_frame"


### PR DESCRIPTION
## 🔎 What type of PR is this? (check all applicable)

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update
- [ ] Others: ...

## 📝 Changes 
<!-- 작업한 내용을 작성해주세요-->


## 🐥 What need this change? 
- Related Issues : #57 
- Closes : #57 


## 📷 Screenshots, Recordings (optional)

## 👫 To Reviewers (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장별 전체 쿠폰 다운로드 기능이 추가되었습니다.
  * 쿠폰 목록 하단 시트에 "전체 다운로드" 버튼이 추가되어, 한 번에 모든 쿠폰을 받을 수 있습니다.

* **UI/UX 개선**
  * 쿠폰 목록 하단 시트가 화면의 70% 높이로 표시되며, 쿠폰 리스트가 스크롤 가능하도록 개선되었습니다.
  * "전체 다운로드" 버튼이 투명 배경 및 라운드 처리로 스타일이 변경되었습니다.
  * 쿠폰 목록 및 멤버십 쿠폰 레이아웃의 하단 마진이 소폭 조정되었습니다.
  * 뒤로가기 버튼을 두 번 눌러야 앱이 종료되는 기능이 메인 화면에 적용되었습니다.

* **버그 수정**
  * 하단 네비게이션에서 화면 전환 시, 뒤로가기 스택에 쌓이지 않도록 동작이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->